### PR TITLE
fix: add broadcast: false to model method Paper#broadcast_replace

### DIFF
--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -56,11 +56,11 @@ class Paper < ApplicationRecord
   private
 
   def broadcast_prepend
-    broadcast_prepend_to :papers, renderable: Papers::ItemComponent.new(item: self)
+    broadcast_prepend_to :papers, renderable: Papers::ItemComponent.new(item: self, broadcast: true)
   end
 
   def broadcast_replace
-    broadcast_replace_to self, renderable: Papers::ItemComponent.new(item: self)
+    broadcast_replace_to self, renderable: Papers::ItemComponent.new(item: self, broadcast: false)
   end
 
   def set_default_elements


### PR DESCRIPTION
# What the problem was 
When papers were generated by AI and updated, the broadcast_replace method was re-rendering components with turbo_stream_from item, creating duplicate subscription elements in the DOM.

# Solution
Set broadcast: false for paper updates since subscriptions only need to be created once during initial paper creation, not recreated on every update.

```rb
def broadcast_replace
  # Don't include subscription on updates - it already exists
  broadcast_replace_to self, renderable: Papers::ItemComponent.new(item: self, broadcast: false)
end
```