### PR TITLE
fix: change #find_by to #find_by! to throw 404 error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
 
 
   def current_theme
-    @current_theme ||= Input::Theme.find_by(slug: params[:theme] || "usd")
+    @current_theme ||= Input::Theme.find_by!(slug: params[:theme] || "usd")
   end
 
   def current_spotify_path


### PR DESCRIPTION
Changed find_by to find_by! in the current_theme method, it is going to raise ActiveRecord::RecordNotFound when a theme isn't found, which returns a 404 Not Found response.