### PR TITLE
Fix visual editor

### DIFF
--- a/app/admin/components/properties_panel_component.html.erb
+++ b/app/admin/components/properties_panel_component.html.erb
@@ -14,8 +14,8 @@
         <span class="label-text">X Position (%)</span>
       <%end%>
       <div class="flex items-center space-x-2">
-        <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.1, data: { visual_editor_target: "panelXInput", action: "input->visual-editor#updateFromPanel", property: "x" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.1, data: { visual_editor_target: "panelXValueInput", action: "input->visual-editor#updateFromPanel", property: "x" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.01, data: { visual_editor_target: "panelXInput", action: "input->visual-editor#updateFromPanel", property: "x" }, class: "range range-primary flex-grow" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelXValueInput", action: "change->visual-editor#updateFromPanel", property: "x" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -25,8 +25,8 @@
         <span class="label-text">Y Position (%)</span>
       <%end%>
       <div class="flex items-center space-x-2">
-        <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.1, data: { visual_editor_target: "panelYInput", action: "input->visual-editor#updateFromPanel", property: "y" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.1, data: { visual_editor_target: "panelYValueInput", action: "input->visual-editor#updateFromPanel", property: "y" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.01, data: { visual_editor_target: "panelYInput", action: "input->visual-editor#updateFromPanel", property: "y" }, class: "range range-primary flex-grow" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelYValueInput", action: "change->visual-editor#updateFromPanel", property: "y" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -44,8 +44,8 @@
         <span class="label-text" data-visual-editor-target="panelSizeLabel">Size</span>
       <%end%>
       <div class="flex items-center space-x-2">
-        <%= range_field_tag nil, nil, min: 8, max: 100, step: 1, data: { visual_editor_target: "panelSizeInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 1, data: { visual_editor_target: "panelSizeValueInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= range_field_tag nil, nil, min: 8, max: 100, step: 0.1, data: { visual_editor_target: "panelSizeInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "range range-primary flex-grow" %>
+        <%= number_field_tag nil, nil, step: 0.1, data: { visual_editor_target: "panelSizeValueInput", action: "change->visual-editor#updateFromPanel", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -56,7 +56,7 @@
       <%end%>
       <div class="flex items-center space-x-2">
         <%= range_field_tag nil, nil, min: 5, max: 100, step: 1, data: { visual_editor_target: "panelMaxWidthInput", action: "input->visual-editor#updateFromPanel", property: "max_text_width" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 1, data: { visual_editor_target: "panelMaxWidthValueInput", action: "input->visual-editor#updateFromPanel", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= number_field_tag nil, nil, step: 1, data: { visual_editor_target: "panelMaxWidthValueInput", action: "change->visual-editor#updateFromPanel", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 

--- a/app/admin/javascript/controllers/visual_editor_controller.js
+++ b/app/admin/javascript/controllers/visual_editor_controller.js
@@ -277,7 +277,7 @@ export default class extends Controller {
       this.panelSizeLabelTarget.textContent = "Font Size (%)";
       this.panelSizeInputTarget.min = 1;
       this.panelSizeInputTarget.max = 20;
-      this.panelSizeInputTarget.step = 0.1;
+      this.panelSizeInputTarget.step = 0.01;
     }
   }
 
@@ -287,6 +287,18 @@ export default class extends Controller {
     const input = event.currentTarget;
     const property = input.dataset.property;
     const value = input.value;
+
+    if (input.type === 'number' && (value.trim() === '' || isNaN(parseFloat(value)))) {
+      const lastValue = this.findInputForElement(this.selectedElement, property).value;
+      const isQr = this.isQrCode(this.selectedElement);
+
+      if (property === 'size') {
+        input.value = parseFloat(lastValue).toFixed(isQr ? 1 : 0);
+      } else {
+        input.value = parseFloat(lastValue).toFixed(1);
+      }
+      return;
+    }
 
     this.updateHiddenInput(this.selectedElement, property, value);
 

--- a/app/admin/javascript/controllers/visual_editor_controller.js
+++ b/app/admin/javascript/controllers/visual_editor_controller.js
@@ -173,13 +173,14 @@ export default class extends Controller {
       const maxWidthInput = this.findInputForElement(element, 'max_text_width');
       const maxWidthPercent = parseFloat(maxWidthInput.value || 30);
       element.style.width = `${maxWidthPercent}%`;
-      element.style.fontSize = `${size}px`;
-      // Let the container height fit the content, then fix it for interact.js
-      element.style.height = 'auto';
-      
+
+      // Font size is now a percentage of the canvas width, making it responsive.
+      const fontSizePx = (size / 100) * this.canvas.offsetWidth;
+      element.style.fontSize = `${fontSizePx}px`;
+
       element.style.height = 'auto';
       const calculatedHeight = element.scrollHeight;
-      element.style.height = `${Math.max(calculatedHeight, size)}px`;
+      element.style.height = `${Math.max(calculatedHeight, fontSizePx)}px`;
     }
   }
 
@@ -273,10 +274,10 @@ export default class extends Controller {
       this.panelSizeInputTarget.max = 50;
       this.panelSizeInputTarget.step = 0.1;
     } else {
-      this.panelSizeLabelTarget.textContent = "Font Size (px)";
-      this.panelSizeInputTarget.min = 8;
-      this.panelSizeInputTarget.max = 150;
-      this.panelSizeInputTarget.step = 1;
+      this.panelSizeLabelTarget.textContent = "Font Size (%)";
+      this.panelSizeInputTarget.min = 1;
+      this.panelSizeInputTarget.max = 20;
+      this.panelSizeInputTarget.step = 0.1;
     }
   }
 

--- a/app/javascript/controllers/canva_controller.js
+++ b/app/javascript/controllers/canva_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
     this.originalWidth = canvas.parentElement.offsetWidth
     this.originalHeight = canvas.parentElement.offsetHeight
 
-    // Set the canvas size in pixels (multiplied by device pixel ratio)
+    // Set the canvas size
     canvas.width = this.originalWidth
     canvas.height = this.originalHeight
 

--- a/app/javascript/controllers/canva_controller.js
+++ b/app/javascript/controllers/canva_controller.js
@@ -12,16 +12,14 @@ export default class extends Controller {
     // Get the canvas element
     const canvas = this.containerTarget
 
-    // Get device pixel ratio
-    const dpr = window.devicePixelRatio || 1
 
     // Store the original dimensions
     this.originalWidth = canvas.parentElement.offsetWidth
     this.originalHeight = canvas.parentElement.offsetHeight
 
     // Set the canvas size in pixels (multiplied by device pixel ratio)
-    canvas.width = this.originalWidth * dpr
-    canvas.height = this.originalHeight * dpr
+    canvas.width = this.originalWidth
+    canvas.height = this.originalHeight
 
     // Set the canvas display size through CSS
     canvas.style.width = `${this.originalWidth}px`
@@ -32,9 +30,6 @@ export default class extends Controller {
 
     // Clear any existing transforms
     this.ctx.setTransform(1, 0, 0, 1, 0, 0)
-
-    // Apply the DPR scaling
-    this.ctx.scale(dpr, dpr)
 
     // Enable image smoothing
     this.ctx.imageSmoothingEnabled = true
@@ -99,7 +94,6 @@ export default class extends Controller {
   }
 
   clear() {
-    const dpr = window.devicePixelRatio || 1
     this.ctx.clearRect(0, 0, this.originalWidth, this.originalHeight)
     if (this.backgroundImage) {
       this.ctx.drawImage(

--- a/app/javascript/controllers/canva_item_controller.js
+++ b/app/javascript/controllers/canva_item_controller.js
@@ -26,24 +26,25 @@ export default class extends Controller {
   draw() {
     if (!this.ctx || this.hiddenValue) return
 
-   const x = this.canvaController.originalWidth * (this.xValue / 100)
-   const y = this.canvaController.originalHeight * (this.yValue / 100)
-
-    const dpr = this.canvaController.dpr || window.devicePixelRatio || 1;
-
-    // Browsers can render fonts slightly differently between the DOM and the Canvas.
-    // This small correction factor visually aligns the canvas font with the editor preview
-    // by making the canvas font slightly smaller to compensate for it appearing larger.
-    const fontCorrectionFactor = 1.04;
-    const scaledFontSize = (this.fontSizeValue / dpr) / fontCorrectionFactor;
-
-    const lineHeight = scaledFontSize * 1.25;
+    const x = this.canvaController.originalWidth * (this.xValue / 100)
+    const y = this.canvaController.originalHeight * (this.yValue / 100)
     const maxWidthPx = this.canvaController.originalWidth * (this.maxTextWidthValue / 100);
 
-    if (this.typeValue === 'text') {
+    if (this.typeValue === 'text' || this.typeValue === 'mnemonic') {
+      const fontCorrectionFactor = 1;
+      // Font size is now a percentage of the canvas width.
+      const fontSizePx = (this.fontSizeValue / 100) * this.canvaController.originalWidth;
+      const scaledFontSize = fontSizePx / fontCorrectionFactor;
+      const lineHeight = scaledFontSize * 1.25;
+
       this.ctx.font = `${scaledFontSize}px Arial`
       this.ctx.fillStyle = this.fontColorValue
-      this.wrapTextByChar(this.ctx, this.textValue || '', x, y + scaledFontSize, maxWidthPx, lineHeight)
+
+      if (this.typeValue === 'text') {
+        this.wrapTextByChar(this.ctx, this.textValue || '', x, y + scaledFontSize, maxWidthPx, lineHeight)
+      } else { // mnemonic
+        this.wrapTextByWord(this.ctx, this.textValue || '', x, y + scaledFontSize, maxWidthPx, lineHeight)
+      }
 
     } else if (this.typeValue === 'image') {
       let imageSize
@@ -53,9 +54,6 @@ export default class extends Controller {
         imageSize = this.fontSizeValue * this.canvaController.originalWidth
       }
       this.ctx.drawImage(this.imageUrl, x, y, imageSize, imageSize)
-    } else if (this.typeValue === 'mnemonic') {
-      // REFACTOR: Pass calculated values to avoid duplicate code.
-      this.drawTextMnemonic(this.textValue, x, y, scaledFontSize, lineHeight, maxWidthPx)
     }
   }
 


### PR DESCRIPTION
# What changed : 
- Font Size in the visual editor is now relative to the paper, and is fully matching the canva
- Remove DPR that used to depend on the browser's height and weight / zoom, when generating a paper, rendering different results for each browser/screen setup.
- Change manual input behaviour to be less rigid.