### PR TITLE
Improve pdf canvas quality

### DIFF
--- a/app/admin/components/properties_panel_component.html.erb
+++ b/app/admin/components/properties_panel_component.html.erb
@@ -44,8 +44,8 @@
         <span class="label-text" data-visual-editor-target="panelSizeLabel">Size</span>
       <%end%>
       <div class="flex items-center space-x-2">
-        <%= range_field_tag nil, nil, min: 8, max: 100, step: 0.1, data: { visual_editor_target: "panelSizeInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.1, data: { visual_editor_target: "panelSizeValueInput", action: "change->visual-editor#updateFromPanel", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= range_field_tag nil, nil, min: 8, max: 100, step: 0.01, data: { visual_editor_target: "panelSizeInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "range range-primary flex-grow" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelSizeValueInput", action: "change->visual-editor#updateFromPanel", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -55,8 +55,8 @@
         <span class="label-text">Max Width (%)</span>
       <%end%>
       <div class="flex items-center space-x-2">
-        <%= range_field_tag nil, nil, min: 5, max: 100, step: 1, data: { visual_editor_target: "panelMaxWidthInput", action: "input->visual-editor#updateFromPanel", property: "max_text_width" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 1, data: { visual_editor_target: "panelMaxWidthValueInput", action: "change->visual-editor#updateFromPanel", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= range_field_tag nil, nil, min: 5, max: 100, step: 0.01, data: { visual_editor_target: "panelMaxWidthInput", action: "input->visual-editor#updateFromPanel", property: "max_text_width" }, class: "range range-primary flex-grow" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelMaxWidthValueInput", action: "change->visual-editor#updateFromPanel", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 

--- a/app/admin/components/properties_panel_component.html.erb
+++ b/app/admin/components/properties_panel_component.html.erb
@@ -15,7 +15,7 @@
       <%end%>
       <div class="flex items-center space-x-2">
         <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.01, data: { visual_editor_target: "panelXInput", action: "input->visual-editor#updateFromPanel", property: "x" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelXValueInput", action: "change->visual-editor#updateFromPanel", property: "x" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelXValueInput", action: "change->visual-editor#updateFromPanel keydown->visual-editor#preventSubmitOnEnter", property: "x" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -26,7 +26,7 @@
       <%end%>
       <div class="flex items-center space-x-2">
         <%= range_field_tag nil, nil, min: 0, max: 100, step: 0.01, data: { visual_editor_target: "panelYInput", action: "input->visual-editor#updateFromPanel", property: "y" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelYValueInput", action: "change->visual-editor#updateFromPanel", property: "y" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelYValueInput", action: "change->visual-editor#updateFromPanel keydown->visual-editor#preventSubmitOnEnter", property: "y" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -45,7 +45,7 @@
       <%end%>
       <div class="flex items-center space-x-2">
         <%= range_field_tag nil, nil, min: 8, max: 100, step: 0.01, data: { visual_editor_target: "panelSizeInput", action: "input->visual-editor#updateFromPanel", property: "size" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelSizeValueInput", action: "change->visual-editor#updateFromPanel", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelSizeValueInput", action: "change->visual-editor#updateFromPanel keydown->visual-editor#preventSubmitOnEnter", property: "size" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 
@@ -56,7 +56,7 @@
       <%end%>
       <div class="flex items-center space-x-2">
         <%= range_field_tag nil, nil, min: 5, max: 100, step: 0.01, data: { visual_editor_target: "panelMaxWidthInput", action: "input->visual-editor#updateFromPanel", property: "max_text_width" }, class: "range range-primary flex-grow" %>
-        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelMaxWidthValueInput", action: "change->visual-editor#updateFromPanel", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
+        <%= number_field_tag nil, nil, step: 0.01, data: { visual_editor_target: "panelMaxWidthValueInput", action: "change->visual-editor#updateFromPanel keydown->visual-editor#preventSubmitOnEnter", property: "max_text_width" }, class: "input input-bordered w-14 text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none" %>
       </div>
     </div>
 

--- a/app/admin/components/visual_editor_component.html.erb
+++ b/app/admin/components/visual_editor_component.html.erb
@@ -4,14 +4,10 @@
 
   <div class="flex justify-between items-center mb-4">
     <div class="btn-group flex gap-2">
-      <button class="btn btn-sm btn-active" data-action="click->visual-editor#switchView" data-visual-editor-target="frontTab" data-view="front">
-        Front
-      </button>
-      <button class="btn btn-sm" data-action="click->visual-editor#switchView" data-visual-editor-target="backTab" data-view="back">
-        Back
-      </button>
+      <%= button_tag "Front", type: "button", class: "btn btn-sm btn-active", data: { action: "click->visual-editor#switchView", visual_editor_target: "frontTab", view: "front" } %>
+      <%= button_tag "Back", type: "button", class: "btn btn-sm", data: { action: "click->visual-editor#switchView", visual_editor_target: "backTab", view: "back" } %>
     </div>
-    <button class="btn btn-ghost btn-sm" data-action="click->visual-editor#resetElements">Reset</button>
+    <%= button_tag "Reset", type: "button", class: "btn btn-ghost btn-sm", data: { action: "click->visual-editor#resetElements" } %>
   </div>
 
   <div data-visual-editor-target="canvas" class="relative bg-gray-200 overflow-hidden rounded" data-action="click->visual-editor#deselect">

--- a/app/admin/javascript/controllers/visual_editor_controller.js
+++ b/app/admin/javascript/controllers/visual_editor_controller.js
@@ -254,7 +254,7 @@ export default class extends Controller {
     this.panelColorInputTarget.value = color;
 
     this.panelSizeInputTarget.value = size;
-    this.panelSizeValueInputTarget.value = parseFloat(size).toFixed(isQr ? 1 : 0);
+    this.panelSizeValueInputTarget.value = parseFloat(size).toFixed(isQr ? 1 : 2);
 
     this.panelMaxWidthInputTarget.value = maxWidth;
     this.panelMaxWidthValueInputTarget.value = parseFloat(maxWidth).toFixed(1);
@@ -272,7 +272,7 @@ export default class extends Controller {
       this.panelSizeLabelTarget.textContent = "Size (%)";
       this.panelSizeInputTarget.min = 1;
       this.panelSizeInputTarget.max = 50;
-      this.panelSizeInputTarget.step = 0.1;
+      this.panelSizeInputTarget.step = 0.01;
     } else {
       this.panelSizeLabelTarget.textContent = "Font Size (%)";
       this.panelSizeInputTarget.min = 1;
@@ -293,7 +293,7 @@ export default class extends Controller {
       const isQr = this.isQrCode(this.selectedElement);
 
       if (property === 'size') {
-        input.value = parseFloat(lastValue).toFixed(isQr ? 1 : 0);
+        input.value = parseFloat(lastValue).toFixed(isQr ? 1 : 2);
       } else {
         input.value = parseFloat(lastValue).toFixed(1);
       }
@@ -323,7 +323,7 @@ export default class extends Controller {
         this.setElementSize(this.selectedElement);
         const isQr = this.isQrCode(this.selectedElement);
         this.panelSizeInputTarget.value = value;
-        this.panelSizeValueInputTarget.value = parseFloat(value).toFixed(isQr ? 1 : 0);
+        this.panelSizeValueInputTarget.value = parseFloat(value).toFixed(isQr ? 1 : 2);
         break;
       case 'max_text_width':
         this.setElementSize(this.selectedElement);

--- a/app/admin/javascript/controllers/visual_editor_controller.js
+++ b/app/admin/javascript/controllers/visual_editor_controller.js
@@ -276,7 +276,7 @@ export default class extends Controller {
     } else {
       this.panelSizeLabelTarget.textContent = "Font Size (%)";
       this.panelSizeInputTarget.min = 1;
-      this.panelSizeInputTarget.max = 20;
+      this.panelSizeInputTarget.max = 10;
       this.panelSizeInputTarget.step = 0.01;
     }
   }
@@ -330,6 +330,13 @@ export default class extends Controller {
         this.panelMaxWidthInputTarget.value = value;
         this.panelMaxWidthValueInputTarget.value = parseFloat(value).toFixed(1);
         break;
+    }
+  }
+  
+  preventSubmitOnEnter(event) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      event.currentTarget.blur(); // De-focus the input, which also triggers the 'change' event
     }
   }
 

--- a/app/javascript/controllers/canva_controller.js
+++ b/app/javascript/controllers/canva_controller.js
@@ -12,14 +12,14 @@ export default class extends Controller {
     // Get the canvas element
     const canvas = this.containerTarget
 
-
+    const qualityScale = 3
     // Store the original dimensions
     this.originalWidth = canvas.parentElement.offsetWidth
     this.originalHeight = canvas.parentElement.offsetHeight
 
     // Set the canvas size
-    canvas.width = this.originalWidth
-    canvas.height = this.originalHeight
+    canvas.width = this.originalWidth * qualityScale
+    canvas.height = this.originalHeight * qualityScale
 
     // Set the canvas display size through CSS
     canvas.style.width = `${this.originalWidth}px`
@@ -30,7 +30,7 @@ export default class extends Controller {
 
     // Clear any existing transforms
     this.ctx.setTransform(1, 0, 0, 1, 0, 0)
-
+    this.ctx.scale(qualityScale, qualityScale)
     // Enable image smoothing
     this.ctx.imageSmoothingEnabled = true
     this.ctx.imageSmoothingQuality = 'high'

--- a/app/javascript/controllers/canva_item_controller.js
+++ b/app/javascript/controllers/canva_item_controller.js
@@ -31,7 +31,7 @@ export default class extends Controller {
     const maxWidthPx = this.canvaController.originalWidth * (this.maxTextWidthValue / 100);
 
     if (this.typeValue === 'text' || this.typeValue === 'mnemonic') {
-      const fontCorrectionFactor = 1;
+      const fontCorrectionFactor = 0.95;
       // Font size is now a percentage of the canvas width.
       const fontSizePx = (this.fontSizeValue / 100) * this.canvaController.originalWidth;
       const scaledFontSize = fontSizePx / fontCorrectionFactor;

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -13,7 +13,9 @@ export default class extends Controller {
       const canvas = await html2canvas(this.contentTarget, {
         scale: 2, // Higher quality
         useCORS: true, // Allow cross-origin images
-        logging: true // Enabled logging
+        logging: true, // Enabled logging
+        scrollX: -window.scrollX,
+        scrollY: -window.scrollY
       })
 
       // Log canvas dimensions


### PR DESCRIPTION
The library `html2canvas` captured the element based on its position within the browser's viewport, and the page's scroll position interfered with this, which explains the offset & partial rendering.

What has been done : 

- Negate the offset by subtracting the current scroll position for the canvas.
- Improve UX for the visual editor alongside that

