### PR TITLE
Fix PDF viewer causing distorted pdf upon download

### DIFF
--- a/app/javascript/controllers/offline/pdf_controller.js
+++ b/app/javascript/controllers/offline/pdf_controller.js
@@ -106,9 +106,17 @@ export default class extends Controller {
   async download(event) {
     event.preventDefault()
 
+    const originalTransform = this.contentTarget.style.transform
+    const originalScrollTop = this.viewportTarget.scrollTop
+    const originalScrollLeft = this.viewportTarget.scrollLeft
+
     try {
+      this.contentTarget.style.transform = '' // Remove zoom transform
+      this.viewportTarget.scrollTop = 0       // Scroll to top
+      this.viewportTarget.scrollLeft = 0      // Scroll to left
       // Convert content to canvas
       const canvas = await html2canvas(this.contentTarget, {
+        
         scale: 2, // Higher quality
         useCORS: true, // Allow cross-origin images
         logging: true, // Enabled logging
@@ -157,6 +165,10 @@ export default class extends Controller {
     } catch (error) {
       console.error("PDF generation failed:", error)
       this.dispatch("error", { detail: { error: error.message } })
+    } finally {
+      this.contentTarget.style.transform = originalTransform
+      this.viewportTarget.scrollTop = originalScrollTop
+      this.viewportTarget.scrollLeft = originalScrollLeft
     }
   }
 }


### PR DESCRIPTION
# What has been done:

- The PDF download logic now temporarily resets the zoom and scroll position of the PDF previewer
- After the capture, the original zoom and scroll state are restored so the user’s view is unchanged. (it flickers..)

Now the generated PDF is always of the same quality and unclipped no matter the zoom annd de scroll position in the viewer.

For the flicker, we reset pdf zoom and position at each download and leave it as it is, what are your thoughts on this @sbounmy @SalmaTalbi ? maybe we explore other solutions.

# Why this solution ?
- `html2canvas` library captures the DOM as it is rendered, so.. if the user is zoomed or scrolled, the downloaded PDF would be low quality, or clipped (cut off)

# Other possible solution : 
-  I attempted to clone the DOM node for the canvas, reset the clone, and download the clone instead to avoid flicker, but cloning broke due to the canvas elements not being copied correctly.



