### PR TITLE
Tokens refresh its count with turbo broadcast in dashboard

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -13,5 +13,9 @@ class Token < ApplicationRecord
 
   def update_user_tokens_sum
     user.update_column(:tokens_sum, user.tokens.sum(:quantity))
+
+    user.broadcast_update_to "user_#{user.id}_tokens",
+      target: "sidebar_tokens_badge",
+      renderable: Tokens::BadgeComponent.new(user: user.reload, class: "badge-lg w-full")
   end
 end

--- a/app/views/main/_sidebar.html.erb
+++ b/app/views/main/_sidebar.html.erb
@@ -39,7 +39,10 @@
       <ul class='flex flex-col gap-2'>
         <% if authenticated? && current_user %>
         <li>
-          <%= render Tokens::BadgeComponent.new(user: current_user, class: "badge-lg w-full") %>
+          <%= turbo_stream_from "user_#{current_user.id}_tokens", class:"hidden" %>
+          <div id="sidebar_tokens_badge" class="flex p-0 w-full rounded-lg">
+            <%= render Tokens::BadgeComponent.new(user: current_user, class: "badge-lg w-full") %>
+          </div>
         </li>
         <li>
           <details>

--- a/e2e/playwright/e2e/bundle.spec.js
+++ b/e2e/playwright/e2e/bundle.spec.js
@@ -33,7 +33,6 @@ test.describe('Bundle generation', () => {
     await app('perform_jobs');
     await expect(page.locator('#preview-column .papers-item-component .bg-cover')).toHaveCount(4); // 2 papers, 2 faces
     await expect(page.locator('#preview-column .papers-item-component .bg-cover').first()).toHaveAttribute('style', /background-image: url\(\'\/rails\/active_storage\/blobs\/redirect\/.*\)/);
-    await page.goto('/dashboard'); // need turbo broadcast to be performed
     await expect(page.locator('.drawer-side')).toContainText('488 ₿ao'); // General check for balance display
   });
 
@@ -57,7 +56,6 @@ test.describe('Bundle generation', () => {
      await app('perform_jobs');
      await expect(page.locator('#preview-column .papers-item-component .bg-cover')).toHaveCount(4); // 2 papers, 2 faces
      await expect(page.locator('#preview-column .papers-item-component .bg-cover').first()).toHaveAttribute('style', /background-image: url\(\'\/rails\/active_storage\/blobs\/redirect\/.*\)/);
-     await page.goto('/dashboard'); // need turbo broadcast to be performed
      await expect(page.locator('.drawer-side')).toContainText('488 ₿ao'); // General check for balance display
    });
 });


### PR DESCRIPTION
# What has been added/changed
- Broadcast tokens sum changes in dashboard everytime there is an update
- Adapt e2e spec so that it no longer does a redirect to check if the tokens sum has correctly changed.