### PR TITLE
Add logo to qr code (maximalist & beginner)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: https://github.com/sbounmy/bitcoin-ruby.git
-  revision: 4b20d628f7b201610d3e90c28ba081b384e95867
+  revision: abff666d0fdbf6b1b8f518479c630f4bb78b6062
   branch: bip39-mnemonic
   specs:
     bitcoin-ruby (0.0.20)
@@ -560,9 +560,9 @@ GEM
     ruby-vips (2.2.3)
       ffi (~> 1.12)
       logger
-    scrypt (3.0.8)
+    scrypt (3.1.0)
       ffi-compiler (>= 1.0, < 2.0)
-      rake (>= 9, < 14)
+      rake (~> 13)
     securerandom (0.4.1)
     shoulda-matchers (6.5.0)
       activesupport (>= 5.2.0)

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -79,27 +79,7 @@ class HongBaosController < ApplicationController
   private
 
   def set_network
-    key = extract_bitcoin_key
-    return unless key.present?
-
-    Current.network = testnet_key?(key) ? :testnet : :mainnet
-    Bitcoin.network = Current.network == :testnet ? :testnet3 : :bitcoin
-  end
-
-  def extract_bitcoin_key
-    key = params[:id] || params.dig(:hong_bao, :scanned_key)
-    return unless key
-
-    # Extract from URL if needed
-    if key.start_with?("http")
-      key.match(%r{/addrs/([^/]+)$}).try(:[], 1) || key
-    else
-      key
-    end
-  end
-
-  def testnet_key?(key)
-    key.match?(/^(tb|m|n|2|9|c)/)
+    Current.network = params[:id].start_with?("tb") ? :testnet : :mainnet
   end
   def set_layout
     if request.format.html?

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -79,7 +79,7 @@ class HongBaosController < ApplicationController
   private
 
   def set_network
-    Current.network = params[:id].start_with?("tb") ? :testnet : :mainnet
+    Current.network = (params[:id] || params["hong_bao"]["scanned_key"]).start_with?("tb") ? :testnet : :mainnet
   end
   def set_layout
     if request.format.html?

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -36,9 +36,13 @@ class HongBaosController < ApplicationController
   end
 
   def show
-    @hong_bao = HongBao.from_scan(params[:id])
-  rescue => e
-    redirect_to hong_baos_path, alert: "Invalid address: #{e.message}"
+    result = HongBaos::Scanner.call(params[:id])
+
+    if result.success?
+      @hong_bao = result.payload
+    else
+      redirect_to hong_baos_path, alert: result.error.user_message
+    end
   end
 
   def form

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -1,6 +1,6 @@
 class HongBaosController < ApplicationController
   allow_unauthenticated_access only: %i[new show form index search utxos transfer]
-  before_action :set_network, only: %i[show form utxos search]
+  before_action :set_network, only: %i[show form utxos]
   layout :set_layout
 
   def index

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -74,7 +74,7 @@ class HongBaosController < ApplicationController
   private
 
   def set_network
-    Current.network = (params[:id] || params[:hong_bao][:scanned_key]).start_with?("tb") ? :testnet : :mainnet
+    Current.network = Current.network_from_key(params[:id] || params[:hong_bao][:scanned_key])
   end
   def set_layout
     if request.format.html?

--- a/app/controllers/hong_baos_controller.rb
+++ b/app/controllers/hong_baos_controller.rb
@@ -79,7 +79,7 @@ class HongBaosController < ApplicationController
   private
 
   def set_network
-    Current.network = (params[:id] || params["hong_bao"]["scanned_key"]).start_with?("tb") ? :testnet : :mainnet
+    Current.network = (params[:id] || params[:hong_bao][:scanned_key]).start_with?("tb") ? :testnet : :mainnet
   end
   def set_layout
     if request.format.html?

--- a/app/javascript/controllers/offline/bitcoin_controller.js
+++ b/app/javascript/controllers/offline/bitcoin_controller.js
@@ -10,6 +10,8 @@ export default class extends Controller {
     customWallet: { type: Boolean, default: false },
     network: { type: String, default: 'mainnet' },
     mode: { type: String, default: 'beginner' },
+    hongbaoLogo: String,
+    bitcoinLogo: String
   }
   static targets = ["utxos"]
 
@@ -63,13 +65,20 @@ export default class extends Controller {
     const activeQrCodeFunction = this.modeValue === 'beginner'
       ? walletInfo.appPublicAddressQrcode
       : walletInfo.publicAddressQrcode;
+    
+    // Choose logo based on mode
+    const logoUrl = this.modeValue === 'beginner' 
+      ? this.hongbaoLogoValue
+      : this.bitcoinLogoValue;
 
     return {
       wallet: this.wallet,
       mnemonicText: this.master?.mnemonic || '',
       // Pass all original info from the wallet, including appPublicAddressQrcode.
       ...walletInfo,
-      publicAddressQrcode: activeQrCodeFunction
+      // we have to override QR code functions to include logo
+      publicAddressQrcode: async () => await activeQrCodeFunction(logoUrl),
+      privateKeyQrcode: walletInfo.privateKeyQrcode  // No logo for private key
     };
   }
 

--- a/app/javascript/services/bitcoin/wallet.js
+++ b/app/javascript/services/bitcoin/wallet.js
@@ -158,6 +158,7 @@ export default class Wallet {
     await QRCode.toCanvas(canvas, data, {
       width: size,
       margin: 1.5,
+      errorCorrectionLevel: 'H', // High error correction because of logo eating qr data
       color: {
         dark: '#000000',
         light: '#ffffff'

--- a/app/javascript/services/bitcoin/wallet.js
+++ b/app/javascript/services/bitcoin/wallet.js
@@ -152,7 +152,7 @@ export default class Wallet {
     if (!data) return null
     
     const canvas = document.createElement('canvas')
-    const size = 150 // Standard QR code size
+    const size = 600 // higher resolution for crisp logos
     
     // Generate QR code
     await QRCode.toCanvas(canvas, data, {
@@ -176,20 +176,26 @@ export default class Wallet {
     const ctx = canvas.getContext('2d')
     const img = new Image()
     
+    // Enable high quality image rendering
+    ctx.imageSmoothingEnabled = true
+    ctx.imageSmoothingQuality = 'high'
+    
     return new Promise((resolve, reject) => {
       img.onload = () => {
-        const size = canvas.width * 0.25 // Logo is 25% of QR code
-        const padding = 5
+        const size = canvas.width * 0.35 // Logo is 35% of QR code
+        const padding = 10 // Larger padding for QR code readability
         const centerX = canvas.width / 2
         const centerY = canvas.height / 2
         
-        // Draw white circle background
+        // Draw white circle background with anti-aliasing
+        ctx.save()
         ctx.beginPath()
         ctx.arc(centerX, centerY, size/2 + padding, 0, 2 * Math.PI)
         ctx.fillStyle = 'white'
         ctx.fill()
+        ctx.restore()
         
-        // Draw the logo
+        ctx.save()
         ctx.drawImage(
           img,
           centerX - size/2,
@@ -197,6 +203,7 @@ export default class Wallet {
           size,
           size
         )
+        ctx.restore()
         resolve()
       }
       img.onerror = reject

--- a/app/javascript/services/bitcoin/wallet.js
+++ b/app/javascript/services/bitcoin/wallet.js
@@ -145,7 +145,7 @@ export default class Wallet {
   }
 
   get appPublicAddress() {
-    return window.location.origin + "/addrs/" + this.address
+    return "https://hbtc.me/a/" + this.address
   }
 
   async #qrcode(data, logoUrl) {

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -9,4 +9,23 @@ class Current < ActiveSupport::CurrentAttributes
   def self.testnet?
     network == :testnet
   end
+
+  TESTNET_ADDRESS_PREFIXES = %w[tb m n 2].freeze
+  TESTNET_WIF_PREFIXES = %w[c 9].freeze
+
+  def self.network_from_key(key)
+    key_str = key.to_s
+
+    testnet_address?(key_str) || testnet_wif?(key_str) ? :testnet : :mainnet
+  end
+
+  def self.testnet_address?(key_str)
+    TESTNET_ADDRESS_PREFIXES.any? { |prefix| key_str.start_with?(prefix) }
+  end
+
+  def self.testnet_wif?(key_str)
+    TESTNET_WIF_PREFIXES.any? { |prefix| key_str.start_with?(prefix) }
+  end
+
+  private_class_method :testnet_address?, :testnet_wif?
 end

--- a/app/models/hong_bao.rb
+++ b/app/models/hong_bao.rb
@@ -33,8 +33,7 @@ class HongBao
     if Bitcoin.valid_address?(key)
       self.address = key
     else
-      # self.private_key = Bitcoin::Key.from_base58(key)
-      pkey = Bitcoin::Key.new(key)
+      pkey = parse_private_key(key)
       self.private_key = pkey.priv
       self.public_key = pkey.pub
       self.address = pkey.addr
@@ -47,5 +46,13 @@ class HongBao
 
   def can_transfer?
     private_key.present?
+  end
+
+  private
+
+  def parse_private_key(key)
+    Bitcoin::Key.from_base58(key)
+  rescue
+    Bitcoin::Key.new(key)
   end
 end

--- a/app/models/hong_bao.rb
+++ b/app/models/hong_bao.rb
@@ -29,7 +29,9 @@ class HongBao
   end
 
   def scanned_key=(key)
+    Current.network = Current.network_from_key(key)
     Bitcoin.network = Current.network_gem
+
     if Bitcoin.valid_address?(key)
       self.address = key
     else

--- a/app/services/hong_baos/scanner.rb
+++ b/app/services/hong_baos/scanner.rb
@@ -28,10 +28,10 @@ module HongBaos
     def extract_address_if_url
       return unless @scanned_key.start_with?("http")
 
-      match = @scanned_key.match(%r{/addrs/([^/]+)$})
+      match = @scanned_key.match(%r{/(addrs|a)/([^/]+)$})
 
       if match
-        @scanned_key = match[1]
+        @scanned_key = match[2]
       else
         raise ScanError.new(
           "Invalid URL format: #{@scanned_key}",

--- a/app/services/hong_baos/scanner.rb
+++ b/app/services/hong_baos/scanner.rb
@@ -1,0 +1,54 @@
+module HongBaos
+  class Scanner < ApplicationService
+    class ScanError < StandardError
+      attr_reader :user_message
+
+      def initialize(message, user_message: nil)
+        super(message)
+        @user_message = user_message || message
+      end
+    end
+
+    def call(scanned_key)
+      @scanned_key = scanned_key
+
+      return failure(ScanError.new("Scanned key is blank", user_message: "Invalid QR code")) unless @scanned_key.present?
+
+      extract_address_if_url
+      create_hong_bao
+
+      success(@hong_bao)
+    rescue => e
+      Rails.logger.error("HongBao scanning failed: #{e.message}")
+      failure(e)
+    end
+
+    private
+
+    def extract_address_if_url
+      return unless @scanned_key.start_with?("http")
+
+      match = @scanned_key.match(%r{/addrs/([^/]+)$})
+
+      if match
+        @scanned_key = match[1]
+      else
+        raise ScanError.new(
+          "Invalid URL format: #{@scanned_key}",
+          user_message: "This QR code contains a URL that is not a Bitcoin wallet"
+        )
+      end
+    end
+
+    def create_hong_bao
+      @hong_bao = HongBao.from_scan(@scanned_key)
+
+      unless @hong_bao.address.present?
+        raise ScanError.new(
+          "HongBao creation failed for key: #{@scanned_key}",
+          user_message: "Invalid QR code"
+        )
+      end
+    end
+  end
+end

--- a/app/views/hong_baos/new.html.erb
+++ b/app/views/hong_baos/new.html.erb
@@ -44,7 +44,9 @@
              data-steps-hidden-class="hidden"
              data-steps-current-value="<%= @current_step %>"
              data-bitcoin-auto-generate-value="true"
-             data-bitcoin-network-value="<%= Current.network %>">
+             data-bitcoin-network-value="<%= Current.network %>"
+             data-bitcoin-hongbao-logo-value="<%= image_url('hongbao-bitcoin.png') %>"
+             data-bitcoin-bitcoin-logo-value="<%= image_url('bitcoin-64x64.svg') %>">
 
           <!-- Sticky Progress Steps -->
           <div class="sticky top-0 rounded-t-3xl z-30 bg-[#F04747] border-b border-[#FFB636]/20">

--- a/app/views/papers/show.html.erb
+++ b/app/views/papers/show.html.erb
@@ -24,7 +24,9 @@
            data-steps-current-value="<%= @current_step %>"
            data-bitcoin-auto-generate-value="true"
            data-bitcoin-network-value="<%= Current.network %>"
-           data-bitcoin-custom-wallet-value="false">
+           data-bitcoin-custom-wallet-value="false"
+           data-bitcoin-hongbao-logo-value="<%= image_url('hongbao-bitcoin.png') %>"
+           data-bitcoin-bitcoin-logo-value="<%= image_url('bitcoin-64x64.svg') %>">
 
        <%= render "papers/preview_pdf", paper: @paper %>
 

--- a/e2e/playwright/e2e/stripe.spec.js
+++ b/e2e/playwright/e2e/stripe.spec.js
@@ -63,9 +63,13 @@ test.describe('Stripe Checkout Flow', () => {
     // Scroll the Manage Billing button into view
     const billingButton = page.getByRole('button', { name: 'Manage Billing' });
     await billingButton.scrollIntoViewIfNeeded();
+    await expect(billingButton).toBeVisible();
+    await expect(billingButton).toBeEnabled();
     await billingButton.click();
 
     await page.waitForURL('https://billing.stripe.com/p/session/**');
+    await page.waitForLoadState('networkidle');
+    
     await expect(page.locator('body')).toContainText("Invoice history");
     await appVcrEjectCassette();
   });

--- a/e2e/playwright/e2e/stripe.spec.js
+++ b/e2e/playwright/e2e/stripe.spec.js
@@ -68,7 +68,7 @@ test.describe('Stripe Checkout Flow', () => {
     await billingButton.click();
 
     await page.waitForURL('https://billing.stripe.com/p/session/**');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('networkidle', { timeout: 120000 }); // 120 seconds timeout
     
     await expect(page.locator('body')).toContainText("Invoice history");
     await appVcrEjectCassette();

--- a/spec/services/hong_baos/scanner_spec.rb
+++ b/spec/services/hong_baos/scanner_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+RSpec.describe HongBaos::Scanner do
+  let(:service) { described_class }
+
+  describe '#call' do
+    context 'when scanned key is blank' do
+      it 'raises a ScanError' do
+        expect {
+          service.call(nil)
+        }.to raise_error(HongBaos::Scanner::ScanError) do |error|
+          expect(error.user_message).to eq("Invalid QR code")
+        end
+      end
+
+      it 'raises a ScanError for empty string' do
+        expect {
+          service.call("")
+        }.to raise_error(HongBaos::Scanner::ScanError) do |error|
+          expect(error.user_message).to eq("Invalid QR code")
+        end
+      end
+    end
+
+    context 'when scanned key is a Bitcoin address' do
+      let(:bitcoin_address) { "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" }
+
+      before do
+        allow(Current).to receive(:network_gem).and_return(:bitcoin)
+      end
+
+      it 'creates a HongBao with the address' do
+        # Use call! to get the result directly (without Response wrapper)
+        result = service.call!(bitcoin_address)
+
+        expect(result).to be_success
+        expect(result.payload).to be_a(HongBao)
+        expect(result.payload.address).to eq(bitcoin_address)
+      end
+    end
+
+    context 'when scanned key is a private key' do
+      let(:private_key) { "5JaTXbAUmfPYZFRwrYaALK48fN6sFJp4rHqq2QSXs8ucfpE4yQU" }
+      let(:expected_address) { "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" }
+
+      before do
+        allow(Current).to receive(:network_gem).and_return(:bitcoin)
+        # Mock Bitcoin::Key to return expected values
+        mock_key = instance_double(Bitcoin::Key,
+          priv: private_key,
+          pub: "mock_public_key",
+          addr: expected_address
+        )
+        allow(Bitcoin::Key).to receive(:new).with(private_key).and_return(mock_key)
+      end
+
+      it 'creates a HongBao containing private key' do
+        # Use call! to get the result directly
+        result = service.call!(private_key)
+
+        expect(result).to be_success
+        expect(result.payload).to be_a(HongBao)
+        expect(result.payload.private_key).to eq(private_key)
+        expect(result.payload.address).to eq(expected_address)
+      end
+    end
+
+    context 'when scanned key is an app URL' do
+      context 'with valid wallet URL' do
+        let(:app_url) { "https://hongbao.bitcoin/addrs/1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" }
+        let(:bitcoin_address) { "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa" }
+
+        before do
+          allow(Current).to receive(:network_gem).and_return(:bitcoin)
+        end
+
+        it 'extracts the address and creates HongBao' do
+          result = service.call!(app_url)
+
+          expect(result).to be_success
+          expect(result.payload).to be_a(HongBao)
+          expect(result.payload.address).to eq(bitcoin_address)
+        end
+      end
+
+      context 'with invalid URL format' do
+        let(:invalid_url) { "https://example.com/not-a-wallet" }
+
+        it 'raises a ScanError with user-friendly message' do
+          expect {
+            service.call(invalid_url)
+          }.to raise_error(HongBaos::Scanner::ScanError) do |error|
+            expect(error.user_message).to eq("This QR code contains a URL that is not a Bitcoin wallet")
+          end
+        end
+      end
+    end
+
+    context 'when HongBao.from_scan returns invalid result' do
+      let(:invalid_key) { "not-a-valid-key" }
+
+      before do
+        allow(Current).to receive(:network_gem).and_return(:bitcoin)
+        allow(Bitcoin).to receive(:valid_address?).with(invalid_key).and_return(false)
+        # Mock Bitcoin::Key to raise error for invalid key
+        allow(Bitcoin::Key).to receive(:new).with(invalid_key).and_raise(RuntimeError, "Invalid key")
+      end
+
+      it 'raises the error' do
+        expect {
+          service.call(invalid_key)
+        }.to raise_error(RuntimeError, "Invalid key")
+      end
+    end
+
+    context 'when unexpected error occurs' do
+      let(:scanned_key) { "test-key" }
+
+      before do
+        allow(HongBao).to receive(:from_scan).and_raise(StandardError, "Unexpected error")
+      end
+
+      it 'raises the original error' do
+        expect {
+          service.call(scanned_key)
+        }.to raise_error(StandardError, "Unexpected error")
+      end
+    end
+  end
+
+  describe 'HongBaos::Scanner::ScanError' do
+    it 'stores user_message when provided' do
+      error = HongBaos::Scanner::ScanError.new("Technical message", user_message: "User friendly message")
+
+      expect(error.message).to eq("Technical message")
+      expect(error.user_message).to eq("User friendly message")
+    end
+
+    it 'uses main message as user_message when not provided' do
+      error = HongBaos::Scanner::ScanError.new("Error message")
+
+      expect(error.message).to eq("Error message")
+      expect(error.user_message).to eq("Error message")
+    end
+  end
+end


### PR DESCRIPTION
# What has been done
 - Added logo support to QR code generation with a white circular background behind the logo
 - Added logo URL values and logic to apply logos based on mode (Hongbao logo for beginner, Bitcoin logo for
   maximalist)
- Weak private key were accepted, and are now rejected (https://github.com/sbounmy/bitcoin-ruby/tree/bip39-mnemonic)
- Handle edge cases for hong bao scanner (if qr code is invalid, if it's an url, etc..)
- Detect network based on public AND private key
   
   
Made sure it's maintainable, if we want to add a new qr code with some logo, we do this :
  ```js
  someNewQrcode: async () => await
  walletInfo.someNewQrcode(logoUrl)
  ```